### PR TITLE
Add 'setRotate' to popmotion-spinnable

### DIFF
--- a/packages/popmotion-spinnable/src/index.js
+++ b/packages/popmotion-spinnable/src/index.js
@@ -60,6 +60,7 @@ export default function spinnable(node, {
   listen(document, 'mouseup touchend').start(stopTracking);
 
   return {
+    setRotate: (angle) => nodeStyler.setRotate(angle),
     stop: () => active && active.stop()
   };
 }


### PR DESCRIPTION
Allow manually overriding the rotate once initiated by exposing a `setRotate` method